### PR TITLE
Error handling for the C code.

### DIFF
--- a/analyse.mk
+++ b/analyse.mk
@@ -1,0 +1,15 @@
+# Analyse for errors
+
+BIN=target/debug/examples/simple_example
+# XXX work out a way to kill sudo
+VALGRIND=sudo valgrind --error-exitcode=1
+
+all: valgrind
+
+.PHONY: valgrind
+
+${BIN}:
+	cargo build --examples
+
+valgrind: ${BIN}
+	${VALGRIND} --track-fds=yes --leak-check=full ${BIN}

--- a/build.rs
+++ b/build.rs
@@ -70,6 +70,7 @@ fn main() {
         assert!(lsb_rel["Release"] == "14.04");
         // Setting -DTRAVIS causes the C API to be stubbed.
         c_build.define("TRAVIS", None);
+        println!("cargo:rustc-cfg=travis");
     }
 
     c_build.compile("traceme");


### PR DESCRIPTION
This replaces all of the `err()` and `errx()` calls with error propagation.

It's quite a big change. Sorry about this. It's been a thing of nightmares to get this right. 

In short, I've minimised the amount of sharing between threads so that it becomes clear(er) by design who should be freeing/closing what.

I've tested by inserting artificial errors into the code at various places and checking the Rust assertions fire. I'm also going to try some static/dynamic analysers on this to see if we can tease out more bugs.

So while I am doing that, can you see anything obviously wrong with this?

Rust error handling will come as a separate PR (did you read the error handling section of the rust book btw?)

Cheers