### PR TITLE
Simplify trace_filename error handling and ensure it has a `.ptt' extension.

### DIFF
--- a/examples/simple_example.rs
+++ b/examples/simple_example.rs
@@ -48,9 +48,7 @@ fn main() {
     let mut res = 0;
     let pid = unsafe { getpid() };
 
-    let mut tracer = Tracer::new()
-                            .trace_filename("simple_example.ptt")
-                            .unwrap();
+    let mut tracer = Tracer::new().trace_filename("simple_example.ptt");
     tracer.start_tracing().unwrap_or_else(|e| {
         panic!(format!("Failed to start tracer: {}", e));
     });

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -8,7 +8,7 @@ pub enum TraceMeError {
     FFINul(ffi::NulError),
     // Our own errors.
     CFailure,
-    EmptyFileName,
+    InvalidFileName(String),
     TracerAlreadyStarted,
     TracerNotStarted,
 }
@@ -31,7 +31,7 @@ impl Display for TraceMeError {
             &TraceMeError::FFIIntoString(ref e) => write!(f, "{}", e),
             &TraceMeError::FFINul(ref e) => write!(f, "{}", e),
             &TraceMeError::CFailure => write!(f, "Calling to C failed"),
-            &TraceMeError::EmptyFileName => write!(f, "Empty file name"),
+            &TraceMeError::InvalidFileName(ref n) => write!(f, "Invalid file name: `{}'", n),
             &TraceMeError::TracerAlreadyStarted => write!(f, "Tracer already started"),
             &TraceMeError::TracerNotStarted => write!(f, "Tracer not started"),
         }


### PR DESCRIPTION
By using a `String` until the last moment when we hand off to C, we can avoid early `NulErrors` and also simplify `make_map_filename` quite a bit.

While we are here, check the trace filename ends in `.ptt`, and add a very basic test.

Makes sense?