### PR TITLE
Check we have permission to trace, and fix file permissions.

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,16 +1,20 @@
-use std::ffi;
+use std::{io, ffi, num};
 use std::fmt::{self, Formatter, Display};
+use ::PERF_PERMS_PATH;
 
 #[derive(Debug)]
 pub enum TraceMeError {
     // Wrapped errors from elsewhere.
     FFIIntoString(ffi::IntoStringError),
     FFINul(ffi::NulError),
+    IO(io::Error),
+    NumParseInt(num::ParseIntError),
     // Our own errors.
     CFailure,
     InvalidFileName(String),
     TracerAlreadyStarted,
     TracerNotStarted,
+    TracingNotPermitted,
 }
 
 impl From<ffi::IntoStringError> for TraceMeError {
@@ -25,15 +29,32 @@ impl From<ffi::NulError> for TraceMeError {
     }
 }
 
+impl From<io::Error> for TraceMeError {
+    fn from(err: io::Error) -> Self {
+        TraceMeError::IO(err)
+    }
+}
+
+impl From<num::ParseIntError> for TraceMeError {
+    fn from(err: num::ParseIntError) -> Self {
+        TraceMeError::NumParseInt(err)
+    }
+}
+
 impl Display for TraceMeError {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
             &TraceMeError::FFIIntoString(ref e) => write!(f, "{}", e),
             &TraceMeError::FFINul(ref e) => write!(f, "{}", e),
+            &TraceMeError::IO(ref e) => write!(f, "{}", e),
+            &TraceMeError::NumParseInt(ref e) => write!(f, "{}", e),
             &TraceMeError::CFailure => write!(f, "Calling to C failed"),
             &TraceMeError::InvalidFileName(ref n) => write!(f, "Invalid file name: `{}'", n),
             &TraceMeError::TracerAlreadyStarted => write!(f, "Tracer already started"),
             &TraceMeError::TracerNotStarted => write!(f, "Tracer not started"),
+            &TraceMeError::TracingNotPermitted =>
+                write!(f, "Tracing not permitted: you must be root or {} must contain -1",
+                       PERF_PERMS_PATH),
         }
     }
 }

--- a/src/traceme.c
+++ b/src/traceme.c
@@ -491,7 +491,7 @@ traceme_start_tracer(struct tracer_conf *tr_conf)
     clean_sem = 1;
 
     // Open the trace output file.
-    out_fd = open(tr_conf->trace_filename, O_WRONLY | O_CREAT);
+    out_fd = open(tr_conf->trace_filename, O_WRONLY | O_CREAT, 0600);
     if (out_fd < 0) {
         failing = true;
         goto clean;

--- a/src/traceme.c
+++ b/src/traceme.c
@@ -55,10 +55,13 @@
 #include <semaphore.h>
 #include <assert.h>
 #include <stdbool.h>
+#include <sys/types.h>
+#include <sys/stat.h>
 
 #define TRACE_OUTPUT    "trace.data"
 #define SYSFS_PT_TYPE   "/sys/bus/event_source/devices/intel_pt/type"
 #define MAX_PT_TYPE_STR 8
+#define MAPS_MODE       S_IRUSR | S_IWUSR
 
 #ifndef INFTIM
 #define INFTIM -1
@@ -137,6 +140,8 @@ stash_maps(pid_t pid, const char *map_filename)
     DEBUG("saving map to %s", map_filename);
     bool ret = true;
 
+    mode_t old_mode = umask(MAPS_MODE);
+
     char *cmd = NULL;
     int res = asprintf(&cmd, "cp /proc/%d/maps %s", pid, map_filename);
     if (res == -1) {
@@ -155,6 +160,8 @@ clean:
     if (cmd) {
         free(cmd);
     }
+    umask(old_mode);
+
     return ret;
 }
 


### PR DESCRIPTION
This change:

 * Checks we have permission to trace.
 * Ensures the `ptt` and `map` files are created with appropriate permissions.

Looks good?

Fixes #7 