### PR TITLE
Guard a Linux specific path.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@ use errors::TraceMeError;
 use std::fs::File;
 use std::io::Read;
 
+#[cfg(target_os="linux")]
 const PERF_PERMS_PATH: &'static str = "/proc/sys/kernel/perf_event_paranoid";
 
 // FFI stubs


### PR DESCRIPTION
Having thought about this a bit, let's keep the platform specific guarding minimal. I think #17 will deal with most of the "guarding" indirectly so to speak.

OK?