### PR TITLE
Introduce "tracing backends" into traceme.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ before_script:
 script:
     - cargo build --examples
     - cargo doc --no-deps
-    - cargo test
+    - RUST_TEST_THREADS=1 cargo test
     - ./target/debug/examples/simple_example

--- a/build.rs
+++ b/build.rs
@@ -36,41 +36,29 @@
 // SOFTWARE.
 
 extern crate gcc;
-use std::env;
-use std::process::Command;
-use std::collections::HashMap;
+use std::path::PathBuf;
 
-fn run_lsb_release(args: Vec<&str>) -> HashMap<String, String> {
-    let output = Command::new("lsb_release")
-                         .args(args)
-                         .output()
-                         .unwrap();
-    assert!(output.status.success());
-    let output_s = String::from_utf8(output.stdout).unwrap();
+const FEATURE_CHECKS_PATH: &str = "feature_checks";
 
-    let mut res = HashMap::new();
-    for line in output_s.lines() {
-        let parts: Vec<&str> = line.split(":").collect();
-        assert!(parts.len() == 2);
-        res.insert(String::from(parts[0].trim()), String::from(parts[1].trim()));
-    }
-    res
+/// Simple feature check, returning `true` if we have the feature.
+///
+/// The checks themselves are in files under `FEATURE_CHECKS_PATH`.
+fn feature_check(filename: &str) -> bool {
+    let mut path = PathBuf::new();
+    path.push(FEATURE_CHECKS_PATH);
+    path.push(filename);
+
+    let mut check_build = gcc::Build::new();
+    check_build.file(path).try_compile("check_perf_pt").is_ok()
 }
 
 fn main() {
     let mut c_build = gcc::Build::new();
-    c_build.file("src/traceme.c").include("src");
 
-    // Travis' Linux setup is too old for what we do with linux-perf.
-    if env::var("TRAVIS").is_ok() {
-        // Crash out when Travis updates to a newer Ubuntu or a different OS.
-        // When this fires, travis may have a new enough linux-perf to test properly.
-        let lsb_rel = run_lsb_release(vec!["-ir"]);
-        assert!(lsb_rel["Distributor ID"] == "Ubuntu");
-        assert!(lsb_rel["Release"] == "14.04");
-        // Setting -DTRAVIS causes the C API to be stubbed.
-        c_build.define("TRAVIS", None);
-        println!("cargo:rustc-cfg=travis");
+    // Check for a new enough Perf to support Intel PT.
+    if feature_check("check_perf_pt.c") {
+        c_build.file("src/backends/perf_pt/perf_pt.c");
+        println!("cargo:rustc-cfg=perf_pt");
     }
 
     c_build.compile("traceme");

--- a/feature_checks/check_perf_pt.c
+++ b/feature_checks/check_perf_pt.c
@@ -1,0 +1,8 @@
+#include <linux/perf_event.h>
+
+int
+check(void)
+{
+    // The perf configuration struct version that first supported Intel PT.
+    return PERF_ATTR_SIZE_VER5;
+}

--- a/src/backends/perf_pt/mod.rs
+++ b/src/backends/perf_pt/mod.rs
@@ -1,0 +1,284 @@
+// Copyright (c) 2017 King's College London
+// created by the Software Development Team <http://soft-dev.org/>
+//
+// The Universal Permissive License (UPL), Version 1.0
+//
+// Subject to the condition set forth below, permission is hereby granted to any
+// person obtaining a copy of this software, associated documentation and/or
+// data (collectively the "Software"), free of charge and under any and all
+// copyright rights in the Software, and any and all patent rights owned or
+// freely licensable by each licensor hereunder covering either (i) the
+// unmodified Software as contributed to or provided by such licensor, or (ii)
+// the Larger Works (as defined below), to deal in both
+//
+// (a) the Software, and
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
+// if one is included with the Software (each a "Larger Work" to which the Software
+// is contributed by such licensors),
+//
+// without restriction, including without limitation the rights to copy, create
+// derivative works of, display, perform, and distribute the Software and make,
+// use, sell, offer for sale, import, export, have made, and have sold the
+// Software and the Larger Work(s), and to sublicense the foregoing rights on
+// either these or other terms.
+//
+// This license is subject to the following condition: The above copyright
+// notice and either this complete permission notice or at a minimum a reference
+// to the UPL must be included in all copies or substantial portions of the
+// Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+use libc::{pid_t, c_char, c_void, getpid, size_t, c_int, geteuid};
+use std::ffi::CString;
+use std::path::PathBuf;
+use errors::TraceMeError;
+use std::fs::File;
+use std::io::Read;
+use Tracer;
+
+// The sysfs path used to set perf permissions.
+const PERF_PERMS_PATH: &'static str = "/proc/sys/kernel/perf_event_paranoid";
+
+// FFI prototypes.
+extern "C" {
+    fn perf_pt_start_tracer(conf: *const PerfPTConf) -> *const c_void;
+    fn perf_pt_stop_tracer(tr_ctx: *const c_void) -> c_int;
+}
+
+// Struct used to communicate a tracing configuration to the C code. Must
+// stay in sync with the C code.
+#[repr(C)]
+struct PerfPTConf {
+    target_pid: pid_t,
+    trace_filename: *const c_char,
+    map_filename: *const c_char,
+    data_bufsize: size_t,
+    aux_bufsize: size_t,
+}
+
+/// A tracer that uses the Linux Perf interface to Intel Processor Trace.
+#[derive(Default)]
+pub struct PerfPTTracer {
+    /// Filename to store the trace to.
+    trace_filename: String,
+    /// PID to trace.
+    target_pid: pid_t,
+    /// Data buffer size, in pages. Must be a power of 2.
+    data_bufsize: size_t,
+    /// Aux buffer size, in pages. Must be a power of 2.
+    aux_bufsize: size_t,
+    /// Opaque C pointer representing the tracer context.
+    tracer_ctx: Option<*const c_void>,
+}
+
+impl PerfPTTracer {
+    /// Create a new tracer.
+    ///
+    /// Returns `Err` if the CPU doesn't support Intel Processor Trace.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use traceme::backends::PerfPTTracer;
+    ///
+    /// let res = PerfPTTracer::new();
+    /// if res.is_ok() {
+    ///     let tracer = res.unwrap().trace_filename("mytrace.ptt").data_bufsize(1024).target_pid(666);
+    /// } else {
+    ///     // CPU doesn't support Intel Processor Trace.
+    /// }
+    /// ```
+    pub fn new() -> Result<Self, TraceMeError> {
+        if Self::pt_supported() {
+            return Ok(Self {
+                trace_filename: String::from("traceme.ptt"),
+                target_pid: unsafe { getpid() },
+                tracer_ctx: None,
+                data_bufsize: 64,
+                aux_bufsize: 1024,
+            });
+        }
+        Err(TraceMeError::HardwareSupport("Intel PT not supported by CPU".into()))
+    }
+
+    /// Set where to write the trace.
+    ///
+    /// # Arguments
+    ///
+    /// * `filename` - The filename in which to store trace packets.
+    pub fn trace_filename(mut self, filename: &str) -> Self {
+        self.trace_filename = String::from(filename);
+        self
+    }
+
+    /// Select which PID to trace.
+    ///
+    /// By default, the current PID is traced.
+    ///
+    /// # Arguments
+    ///
+    /// * `pid` - The PID to trace.
+    pub fn target_pid(mut self, pid: pid_t) -> Self {
+        self.target_pid = pid;
+        self
+    }
+
+    /// Set the PT data buffer size.
+    ///
+    /// # Arguments
+    ///
+    /// * `size` - The data buffer size to use.
+    pub fn data_bufsize(mut self, size: usize) -> Self {
+        self.data_bufsize = size;
+        self
+    }
+
+    /// Set the PT aux buffer size.
+    ///
+    /// # Arguments
+    ///
+    /// * `size` - The aux buffer size to use.
+    pub fn aux_bufsize(mut self, size: usize) -> Self {
+        self.aux_bufsize = size;
+        self
+    }
+
+    /// Make the map filename by setting/adding a ".map" extension to `trace_filename`.
+    fn make_map_filename(trace_filename: &str) -> Result<String, TraceMeError> {
+        let mut pb = PathBuf::from(trace_filename);
+        if !pb.set_extension("map") {
+            return Err(TraceMeError::InvalidFileName("".to_string()));
+        }
+        let map_filename = pb.to_str().ok_or(TraceMeError::InvalidFileName("".to_string()))?;
+        Ok(String::from(map_filename))
+    }
+
+    fn check_perf_perms() -> Result<(), TraceMeError> {
+        if unsafe { geteuid() } == 0 {
+            // Root can always trace.
+            return Ok(());
+        }
+
+        let mut f = File::open(&PERF_PERMS_PATH)?;
+        let mut buf = String::new();
+        f.read_to_string(&mut buf)?;
+        let perm = buf.trim().parse::<i8>()?;
+        if perm != -1 {
+            let msg = format!("Tracing not permitted: you must be root or {} must contain -1",
+                           PERF_PERMS_PATH);
+            return Err(TraceMeError::TracingNotPermitted(msg));
+        }
+
+        Ok(())
+    }
+
+    /// Checks if the CPU supports Intel Processor Trace.
+    fn pt_supported() -> bool {
+        const LEAF: u32 = 0x07;
+        const SUBPAGE: u32 = 0x0;
+        const EBX_BIT: u32 = 1 << 25;
+        let ebx_out: u32;
+
+        unsafe {
+            asm!(r"
+                  mov $1, %eax;
+                  mov $2, %ecx;
+                  cpuid;"
+                : "={ebx}" (ebx_out)
+                : "i" (LEAF), "i" (SUBPAGE)
+                : "eax", "ecx", "edx"
+                : "volatile");
+        }
+
+        if ebx_out & (EBX_BIT) != 0 {
+            return true;
+        }
+        false
+    }
+}
+
+impl Tracer for PerfPTTracer {
+    fn start_tracing(&mut self) -> Result<(), TraceMeError> {
+        PerfPTTracer::check_perf_perms()?;
+        if self.tracer_ctx.is_some() {
+            return Err(TraceMeError::TracerAlreadyStarted);
+        }
+        if !self.trace_filename.ends_with(".ptt") {
+            return Err(TraceMeError::InvalidFileName(String::from(self.trace_filename.clone())));
+        }
+
+        // Build the C configuration struct
+        let map_filename_c = CString::new(PerfPTTracer::make_map_filename(&self.trace_filename)?)?;
+        let trace_filename_c = CString::new(self.trace_filename.clone())?;
+        let tr_conf = PerfPTConf {
+            target_pid: self.target_pid,
+            trace_filename: trace_filename_c.as_ptr(),
+            map_filename: map_filename_c.as_ptr(),
+            data_bufsize: self.data_bufsize,
+            aux_bufsize: self.aux_bufsize,
+        };
+
+        // Call C
+        let conf_ptr = &tr_conf as *const PerfPTConf;
+        let opq_ptr = unsafe {
+            perf_pt_start_tracer(conf_ptr)
+        };
+        if opq_ptr.is_null() {
+            return Err(TraceMeError::CFailure);
+        }
+        self.tracer_ctx = Some(opq_ptr);
+        Ok(())
+    }
+
+    fn stop_tracing(&mut self) -> Result<(), TraceMeError> {
+        let tr_ctx = self.tracer_ctx.ok_or(TraceMeError::TracerNotStarted)?;
+        let rc = unsafe {
+            perf_pt_stop_tracer(tr_ctx)
+        };
+        if rc == -1 {
+            return Err(TraceMeError::CFailure);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PerfPTTracer;
+    use ::test_helpers;
+
+    fn run_test_helper<F>(f: F)  where F: Fn(PerfPTTracer) {
+        let res = PerfPTTracer::new();
+        // Only run the test if the CPU supports Intel PT.
+        if res.is_ok() {
+            f(res.unwrap());
+        }
+    }
+
+    #[test]
+    fn test_basic_usage() {
+        run_test_helper(test_helpers::test_basic_usage);
+    }
+
+    #[test]
+    fn test_already_started() {
+        run_test_helper(test_helpers::test_already_started);
+    }
+
+    #[test]
+    fn test_not_started() {
+        run_test_helper(test_helpers::test_not_started);
+    }
+
+    #[test]
+    fn test_map_filename() {
+        assert!(PerfPTTracer::make_map_filename("trace.ptt").unwrap() == "trace.map");
+    }
+}

--- a/src/backends/perf_pt/perf_pt.c
+++ b/src/backends/perf_pt/perf_pt.c
@@ -137,10 +137,9 @@ stash_maps(pid_t pid, const char *map_filename)
     DEBUG("saving map to %s", map_filename);
     bool ret = true;
 
-    mode_t old_mode = umask(MAPS_MODE);
-
     char *cmd = NULL;
-    int res = asprintf(&cmd, "cp /proc/%d/maps %s", pid, map_filename);
+    int res = asprintf(&cmd, "cp /proc/%d/maps %s && chmod 600 %s",
+                       pid, map_filename, map_filename);
     if (res == -1) {
         cmd = NULL; // cmd undefined after error.
         ret = false;
@@ -157,7 +156,6 @@ clean:
     if (cmd) {
         free(cmd);
     }
-    umask(old_mode);
 
     return ret;
 }

--- a/src/backends/perf_pt/perf_pt.c
+++ b/src/backends/perf_pt/perf_pt.c
@@ -113,21 +113,18 @@ struct tracer_thread_args {
 
 
 // Private prototypes.
-#ifndef TRAVIS
 static bool stash_maps(pid_t, const char *);
 static bool write_buf_to_disk(int, void *, __u64);
 static bool read_circular_buf(void *, __u64, __u64, __u64 *, int);
 static bool poll_loop(int, int, int, struct perf_event_mmap_page *, void *);
 static void *tracer_thread(void *);
 static int open_perf(pid_t target_pid);
-#endif
 
 // Exposed Prototypes.
-struct tracer_ctx *traceme_start_tracer(struct tracer_conf *);
-int traceme_stop_tracer(struct tracer_ctx *tr_ctx);
+struct tracer_ctx *perf_pt_start_tracer(struct tracer_conf *);
+int perf_pt_stop_tracer(struct tracer_ctx *tr_ctx);
 
 
-#ifndef TRAVIS
 /*
  * Save linker relocation decisions so that you can later recover the
  * instruction stream from an on-disk binary.
@@ -425,7 +422,6 @@ clean:
     }
     return (void *) ret;
 }
-#endif // TRAVIS.
 
 /*
  * --------------------------------------
@@ -442,17 +438,13 @@ clean:
  * Returns a pointer to a tracer context, or NULL on error.
  */
 struct tracer_ctx *
-traceme_start_tracer(struct tracer_conf *tr_conf)
+perf_pt_start_tracer(struct tracer_conf *tr_conf)
 {
     DEBUG("target_pid=%d, trace_filename=%s, map_filename=%s, "
         "data_bufsize=%zd, aux_bufsize=%zd", tr_conf->target_pid,
         tr_conf->trace_filename, tr_conf->map_filename,
         tr_conf->data_bufsize, tr_conf->aux_bufsize);
 
-#ifdef TRAVIS
-    DEBUG("Travis mode. Not starting tracing");
-    return NULL;
-#else
     bool failing = false;
     struct tracer_ctx *tr_ctx = NULL;
     int perf_fd = -1, out_fd = -1;
@@ -573,7 +565,6 @@ clean:
         DEBUG("failure");
     }
     return ret;
-#endif
 }
 
 /*
@@ -585,12 +576,7 @@ clean:
  * Returns 0 on success and -1 on failure.
  */
 int
-traceme_stop_tracer(struct tracer_ctx *tr_ctx) {
-#ifdef TRAVIS
-    (void) tr_ctx;
-    DEBUG("Travis mode. Not stopping tracing");
-    return -1;
-#else
+perf_pt_stop_tracer(struct tracer_ctx *tr_ctx) {
     DEBUG("stopping tracer");
 
     int ret = 0;
@@ -633,5 +619,4 @@ traceme_stop_tracer(struct tracer_ctx *tr_ctx) {
         DEBUG("failure");
     }
     return ret;
-#endif
 }

--- a/src/backends/perf_pt/perf_pt.c
+++ b/src/backends/perf_pt/perf_pt.c
@@ -331,7 +331,7 @@ open_perf(pid_t target_pid) {
     ret = syscall(SYS_perf_event_open, &attr, target_pid, -1, -1, 0);
 
 clean:
-    if (fclose(pt_type_file) == -1) {
+    if ((pt_type_file != NULL) && (fclose(pt_type_file) == -1)) {
         ret = -1;
     }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,5 @@
 use std::{io, ffi, num};
 use std::fmt::{self, Formatter, Display};
-use ::PERF_PERMS_PATH;
 
 #[derive(Debug)]
 pub enum TraceMeError {
@@ -11,10 +10,11 @@ pub enum TraceMeError {
     NumParseInt(num::ParseIntError),
     // Our own errors.
     CFailure,
+    HardwareSupport(String),
     InvalidFileName(String),
     TracerAlreadyStarted,
     TracerNotStarted,
-    TracingNotPermitted,
+    TracingNotPermitted(String),
 }
 
 impl From<ffi::IntoStringError> for TraceMeError {
@@ -48,13 +48,12 @@ impl Display for TraceMeError {
             &TraceMeError::FFINul(ref e) => write!(f, "{}", e),
             &TraceMeError::IO(ref e) => write!(f, "{}", e),
             &TraceMeError::NumParseInt(ref e) => write!(f, "{}", e),
+            &TraceMeError::HardwareSupport(ref m) => write!(f, "Hardware support: {}", m),
             &TraceMeError::CFailure => write!(f, "Calling to C failed"),
             &TraceMeError::InvalidFileName(ref n) => write!(f, "Invalid file name: `{}'", n),
             &TraceMeError::TracerAlreadyStarted => write!(f, "Tracer already started"),
             &TraceMeError::TracerNotStarted => write!(f, "Tracer not started"),
-            &TraceMeError::TracingNotPermitted =>
-                write!(f, "Tracing not permitted: you must be root or {} must contain -1",
-                       PERF_PERMS_PATH),
+            &TraceMeError::TracingNotPermitted(ref m) => write!(f, "{}", m),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,195 +37,59 @@
 
 #![cfg_attr(feature="clippy", feature(plugin))]
 #![cfg_attr(feature="clippy", plugin(clippy))]
+#![feature(asm)]
 
 extern crate libc;
 
-mod errors;
+pub mod errors;
+pub mod backends;
 
-use libc::{pid_t, c_char, c_void, getpid, size_t, c_int, geteuid};
-use std::ffi::CString;
-use std::path::PathBuf;
 use errors::TraceMeError;
-use std::fs::File;
-use std::io::Read;
 
-#[cfg(target_os="linux")]
-const PERF_PERMS_PATH: &'static str = "/proc/sys/kernel/perf_event_paranoid";
-
-// FFI stubs
-#[link(name = "traceme")]
-extern "C" {
-    fn traceme_start_tracer(conf: *const TracerConf) -> *const c_void;
-    fn traceme_stop_tracer(tr_ctx: *const c_void) -> c_int;
-}
-
-// Struct used to communicate a tracing configuration to C. Must stay in sync with the C code.
-#[repr(C)]
-struct TracerConf {
-    target_pid: pid_t,
-    trace_filename: *const c_char,
-    map_filename: *const c_char,
-    data_bufsize: size_t,
-    aux_bufsize: size_t,
-}
-
-/// Represents an instance of the Intel PT tracer.
-#[derive(Default)]
-pub struct Tracer {
-    /// Filename to store the trace to.
-    trace_filename: String,
-    /// PID to trace.
-    target_pid: pid_t,
-    /// Data buffer size, in pages. Must be a power of 2.
-    data_bufsize: size_t,
-    /// Aux buffer size, in pages. Must be a power of 2.
-    aux_bufsize: size_t,
-    /// Opaque C pointer representing the tracer context.
-    tracer_ctx: Option<*const c_void>,
-}
-
-impl Tracer {
-    /// Create a new tracer.
+/// The interface offered by all tracer types.
+///
+/// It is the job of the consumer of this library to decide which specific tracer type to
+/// instantiate, and to set it up using its type-specific configuration methods.
+pub trait Tracer {
+    /// Start recording a trace.
     ///
-    /// # Example
-    ///
-    /// ```
-    /// use traceme::Tracer;
-    ///
-    /// Tracer::new().trace_filename("mytrace.ptt").data_bufsize(1024).target_pid(666);
-    /// ```
-    pub fn new() -> Self {
-        Tracer {
-            trace_filename: String::from("traceme.ptt"),
-            target_pid: unsafe { getpid() },
-            tracer_ctx: None,
-            data_bufsize: 64,
-            aux_bufsize: 1024,
-        }
-    }
-
-    /// Set where to write the trace.
-    ///
-    /// # Arguments
-    ///
-    /// * `filename` - The filename in which to store trace packets.
-    pub fn trace_filename(mut self, filename: &str) -> Self {
-        self.trace_filename = String::from(filename);
-        self
-    }
-
-    /// Select which PID to trace.
-    ///
-    /// By default, the current PID is traced.
-    ///
-    /// # Arguments
-    ///
-    /// * `pid` - The PID to trace.
-    pub fn target_pid(mut self, pid: pid_t) -> Self {
-        self.target_pid = pid;
-        self
-    }
-
-    /// Set the PT data buffer size.
-    ///
-    /// # Arguments
-    ///
-    /// * `size` - The data buffer size to use.
-    pub fn data_bufsize(mut self, size: usize) -> Self {
-        self.data_bufsize = size;
-        self
-    }
-
-    /// Set the PT aux buffer size.
-    ///
-    /// # Arguments
-    ///
-    /// * `size` - The aux buffer size to use.
-    pub fn aux_bufsize(mut self, size: usize) -> Self {
-        self.aux_bufsize = size;
-        self
-    }
-
-    /// Make the map filename by setting/adding a ".map" extension to `trace_filename`.
-    fn make_map_filename(trace_filename: &str) -> Result<String, TraceMeError> {
-        let mut pb = PathBuf::from(trace_filename);
-        if !pb.set_extension("map") {
-            return Err(TraceMeError::InvalidFileName("".to_string()));
-        }
-        let map_filename = pb.to_str().ok_or(TraceMeError::InvalidFileName("".to_string()))?;
-        Ok(String::from(map_filename))
-    }
-
-    fn check_perf_perms() -> Result<(), TraceMeError> {
-        if unsafe { geteuid() } == 0 {
-            // Root can always trace.
-            return Ok(());
-        }
-
-        let mut f = File::open(&PERF_PERMS_PATH)?;
-        let mut buf = String::new();
-        f.read_to_string(&mut buf)?;
-        let perm = buf.trim().parse::<i8>()?;
-        if perm != -1 {
-            return Err(TraceMeError::TracingNotPermitted);
-        }
-
-        Ok(())
-    }
-
-    /// Records execution of the selected PID into the chosen output file.
-    ///
-    /// Tracing continues until [stop_tracing](struct.Tracer.html#method.stop_tracing) is called.
-    pub fn start_tracing(&mut self) -> Result<(), TraceMeError> {
-        if cfg!(not(travis)) {
-            Tracer::check_perf_perms()?;
-        }
-        if self.tracer_ctx.is_some() {
-            return Err(TraceMeError::TracerAlreadyStarted);
-        }
-        if !self.trace_filename.ends_with(".ptt") {
-            return Err(TraceMeError::InvalidFileName(String::from(self.trace_filename.clone())));
-        }
-
-        // Build the C configuration struct
-        let map_filename_c = CString::new(Tracer::make_map_filename(&self.trace_filename)?)?;
-        let trace_filename_c = CString::new(self.trace_filename.clone())?;
-        let tr_conf = TracerConf {
-            target_pid: self.target_pid,
-            trace_filename: trace_filename_c.as_ptr(),
-            map_filename: map_filename_c.as_ptr(),
-            data_bufsize: self.data_bufsize,
-            aux_bufsize: self.aux_bufsize,
-        };
-
-        // Call C
-        let conf_ptr = &tr_conf as *const TracerConf;
-        let opq_ptr = unsafe {
-            traceme_start_tracer(conf_ptr as *const TracerConf)
-        };
-        if cfg!(not(travis)) && opq_ptr == std::ptr::null() {
-           return Err(TraceMeError::CFailure);
-        }
-        self.tracer_ctx = Some(opq_ptr);
-        Ok(())
-    }
-
+    /// Tracing continues until [stop_tracing](trait.Tracer.html#method.stop_tracing) is called.
+    fn start_tracing(&mut self) -> Result<(), TraceMeError>;
     /// Turns off the tracer.
     ///
-    /// [start_tracing](struct.Tracer.html#method.start_tracing) must have been called prior.
-    pub fn stop_tracing(&self) -> Result<(), TraceMeError> {
-        let tr_ctx = self.tracer_ctx.ok_or(TraceMeError::TracerNotStarted)?;
-        let rc = unsafe {
-            traceme_stop_tracer(tr_ctx)
-        };
-        if cfg!(not(travis))  && rc == -1 {
-           return Err(TraceMeError::CFailure);
-        }
-        Ok(())
-    }
+    /// [start_tracing](trait.Tracer.html#method.start_tracing) must have been called prior.
+    fn stop_tracing(&mut self) -> Result<(), TraceMeError>;
 }
 
-#[test]
-fn test_make_map_filename_0000() {
-    assert!(Tracer::make_map_filename("trace.ptt").unwrap() == "trace.map");
+/// Test helpers.
+///
+/// Each struct implementing the [Tracer](trait.Tracer.html) trait should include tests calling the
+/// following helpers.
+#[cfg(test)]
+mod test_helpers {
+    use super::{TraceMeError, Tracer};
+
+    /// Check that starting and stopping a tracer works.
+    pub fn test_basic_usage<T>(mut tracer: T) where T: Tracer {
+        tracer.start_tracing().unwrap();
+        tracer.stop_tracing().unwrap();
+    }
+
+    /// Check that starting a tracer twice makes an appropriate error.
+    pub fn test_already_started<T>(mut tracer: T) where T: Tracer {
+        tracer.start_tracing().unwrap();
+        match tracer.start_tracing() {
+            Err(TraceMeError::TracerAlreadyStarted) => (),
+            _ => panic!(),
+        };
+        tracer.stop_tracing().unwrap();
+    }
+
+    /// Check that stopping an unstarted tracer makes an appropriate error.
+    pub fn test_not_started<T>(mut tracer: T) where T: Tracer {
+        match tracer.stop_tracing() {
+            Err(TraceMeError::TracerNotStarted) => (),
+            _ => panic!(),
+        };
+    }
 }


### PR DESCRIPTION
To begin with we have "pt_perf" and "dummy" backends.

 * pt_perf uses Linux Perf to collect Intel Processor Trace packets.
 * dummy is a fall-back backend which does nothing.

Conditional compilation is used to include/exclude the pt_perf backend
depending upon the the outcome of a (crude) feature check in build.rs.

It's up to the consumer if traceme to choose an appropriate tracing backend and configure it (instantiation and configuration is specific to each tracer, and not part of the `Tracer` trait).

Note that the compiler output appears for failing feature checks appear in the `cargo build` output (and so in the travis log too). A bit annoying, but not a show stopper. I'm hoping the Rust community will devise a better feature check mechanism in the future.

Looks good?

Fixes #10, #16, #17.