### PR TITLE
Kill map file

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -10,6 +10,7 @@ pub enum TraceMeError {
     NumParseInt(num::ParseIntError),
     // Our own errors.
     CFailure,
+    ElfError(String),
     HardwareSupport(String),
     InvalidFileName(String),
     TracerAlreadyStarted,
@@ -50,6 +51,7 @@ impl Display for TraceMeError {
             &TraceMeError::NumParseInt(ref e) => write!(f, "{}", e),
             &TraceMeError::HardwareSupport(ref m) => write!(f, "Hardware support: {}", m),
             &TraceMeError::CFailure => write!(f, "Calling to C failed"),
+            &TraceMeError::ElfError(ref m) => write!(f, "ELF error: {}", m),
             &TraceMeError::InvalidFileName(ref n) => write!(f, "Invalid file name: `{}'", n),
             &TraceMeError::TracerAlreadyStarted => write!(f, "Tracer already started"),
             &TraceMeError::TracerNotStarted => write!(f, "Tracer not started"),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,3 +1,40 @@
+// Copyright (c) 2017-2018 King's College London
+// created by the Software Development Team <http://soft-dev.org/>
+//
+// The Universal Permissive License (UPL), Version 1.0
+//
+// Subject to the condition set forth below, permission is hereby granted to any
+// person obtaining a copy of this software, associated documentation and/or
+// data (collectively the "Software"), free of charge and under any and all
+// copyright rights in the Software, and any and all patent rights owned or
+// freely licensable by each licensor hereunder covering either (i) the
+// unmodified Software as contributed to or provided by such licensor, or (ii)
+// the Larger Works (as defined below), to deal in both
+//
+// (a) the Software, and
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
+// if one is included with the Software (each a "Larger Work" to which the Software
+// is contributed by such licensors),
+//
+// without restriction, including without limitation the rights to copy, create
+// derivative works of, display, perform, and distribute the Software and make,
+// use, sell, offer for sale, import, export, have made, and have sold the
+// Software and the Larger Work(s), and to sublicense the foregoing rights on
+// either these or other terms.
+//
+// This license is subject to the following condition: The above copyright
+// notice and either this complete permission notice or at a minimum a reference
+// to the UPL must be included in all copies or substantial portions of the
+// Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 use std::{io, ffi, num};
 use std::fmt::{self, Formatter, Display};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 King's College London
+// Copyright (c) 2017-2018 King's College London
 // created by the Software Development Team <http://soft-dev.org/>
 //
 // The Universal Permissive License (UPL), Version 1.0
@@ -35,14 +35,15 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#![cfg_attr(all(perf_pt, target_arch = "x86_64"), feature(asm))]
 #![cfg_attr(feature="clippy", feature(plugin))]
 #![cfg_attr(feature="clippy", plugin(clippy))]
-#![feature(asm)]
 
 extern crate libc;
 
 pub mod errors;
 pub mod backends;
+pub mod util;
 
 use errors::TraceMeError;
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,0 +1,108 @@
+// Copyright (c) 2018 King's College London
+// created by the Software Development Team <http://soft-dev.org/>
+//
+// The Universal Permissive License (UPL), Version 1.0
+//
+// Subject to the condition set forth below, permission is hereby granted to any
+// person obtaining a copy of this software, associated documentation and/or
+// data (collectively the "Software"), free of charge and under any and all
+// copyright rights in the Software, and any and all patent rights owned or
+// freely licensable by each licensor hereunder covering either (i) the
+// unmodified Software as contributed to or provided by such licensor, or (ii)
+// the Larger Works (as defined below), to deal in both
+//
+// (a) the Software, and
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
+// if one is included with the Software (each a "Larger Work" to which the Software
+// is contributed by such licensors),
+//
+// without restriction, including without limitation the rights to copy, create
+// derivative works of, display, perform, and distribute the Software and make,
+// use, sell, offer for sale, import, export, have made, and have sold the
+// Software and the Larger Work(s), and to sublicense the foregoing rights on
+// either these or other terms.
+//
+// This license is subject to the following condition: The above copyright
+// notice and either this complete permission notice or at a minimum a reference
+// to the UPL must be included in all copies or substantial portions of the
+// Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+use libc::{c_int, uintptr_t};
+use ::errors::TraceMeError;
+
+// FFI prototypes.
+extern "C" {
+    fn traceme_exec_base(addr: *const uintptr_t) -> c_int;
+}
+
+/// Get the relocated virtual start address of the executable code for the current program.
+pub fn exec_base() -> Result<usize, TraceMeError> {
+    let mut addr: uintptr_t = 0;
+    match unsafe {traceme_exec_base(&mut addr as *const uintptr_t)} {
+        0 => Err(TraceMeError::ElfError(String::from("Failed to get executable base address"))),
+        1 => Ok(addr as usize),
+        _ => unreachable!(),
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod test_linux {
+    use super::exec_base;
+
+    use libc::getpid;
+    use std::path::PathBuf;
+    use std::fs::File;
+    use std::io::BufReader;
+    use std::io::BufRead;
+    use std::env::current_exe;
+
+    /// Check we can get the exec_base() address and that the procfs map file agrees.
+    #[test]
+    fn test_linux_exec_base() {
+        let got_base = exec_base().unwrap();
+
+        let mut path = PathBuf::from("/proc");
+        path.push(unsafe {getpid()}.to_string());
+        path.push("maps");
+        let file = File::open(path).unwrap();
+
+        // Search for the executable base address.
+        let exe = current_exe().unwrap();
+        let mut expect_base: usize = 0;
+        let rdr = BufReader::new(file);
+        for line in rdr.lines() {
+            let line = line.unwrap();
+            let mut parts = line.split_whitespace();
+            let addrs = parts.next().unwrap();
+            let flags = parts.next().unwrap();
+            let path = parts.nth(3).unwrap();
+
+            if path == exe.to_str().unwrap() && flags == "r-xp" {
+                let mut addrs_parts = addrs.split('-');
+                expect_base = usize::from_str_radix(addrs_parts.next().unwrap(), 16).unwrap();
+                break;
+            }
+        }
+        assert_eq!(got_base, expect_base);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::exec_base;
+
+    /// Check we can get the exec_base() address.
+    #[test]
+    fn test_exec_base() {
+        let got_base = exec_base().unwrap();
+        assert_ne!(got_base, 0); // Code will never be mapped at 0.
+    }
+}


### PR DESCRIPTION
This kills the "stashing of the map file" and the crufty code around it.

Instead of copying a file out of procfs (which relies on the OS having proc, and would have to be sucked in and parsed later), we use the semi-portable `dl_iterate_phdr()` API to work with in-memory data structures. This also helps with tests, since the map flie is one less file to race in parallel testing (the trace file still races -- fixing in #8).

The new code isn't used (apart from in tests), but will be needed later to relate PT packets to the binary code.

Looks good?