### PR TITLE
Misc tidying

### DIFF
--- a/examples/simple_example.rs
+++ b/examples/simple_example.rs
@@ -51,17 +51,17 @@ fn tracer() -> Box<Tracer> {
         #[cfg(all(perf_pt, target_arch = "x86_64"))] {
             let res = PerfPTTracer::new();
             if res.is_ok() {
-                return Box::new(res.unwrap().trace_filename("simple_example.ptt"));
+                Box::new(res.unwrap().trace_filename("simple_example.ptt"))
             } else {
                 // CPU doesn't have Intel PT support.
-                return Box::new(DummyTracer::new());
+                Box::new(DummyTracer::new())
             }
         }
         #[cfg(not(all(perf_pt, target_arch = "x86_64")))] {
-            return Box::new(DummyTracer::new());
+            Box::new(DummyTracer::new())
         }
     } else {
-        return Box::new(DummyTracer::new());
+        Box::new(DummyTracer::new())
     }
 }
 

--- a/src/backends/perf_pt/mod.rs
+++ b/src/backends/perf_pt/mod.rs
@@ -199,7 +199,7 @@ impl Tracer for PerfPTTracer {
             return Err(TraceMeError::TracerAlreadyStarted);
         }
         if !self.trace_filename.ends_with(".ptt") {
-            return Err(TraceMeError::InvalidFileName(String::from(self.trace_filename.clone())));
+            return Err(TraceMeError::InvalidFileName(self.trace_filename.clone()));
         }
 
         // Build the C configuration struct

--- a/src/backends/perf_pt/mod.rs
+++ b/src/backends/perf_pt/mod.rs
@@ -43,7 +43,7 @@ use std::io::Read;
 use Tracer;
 
 // The sysfs path used to set perf permissions.
-const PERF_PERMS_PATH: &'static str = "/proc/sys/kernel/perf_event_paranoid";
+const PERF_PERMS_PATH: &str = "/proc/sys/kernel/perf_event_paranoid";
 
 // FFI prototypes.
 extern "C" {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -81,18 +81,18 @@ impl From<num::ParseIntError> for TraceMeError {
 
 impl Display for TraceMeError {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        match self {
-            &TraceMeError::FFIIntoString(ref e) => write!(f, "{}", e),
-            &TraceMeError::FFINul(ref e) => write!(f, "{}", e),
-            &TraceMeError::IO(ref e) => write!(f, "{}", e),
-            &TraceMeError::NumParseInt(ref e) => write!(f, "{}", e),
-            &TraceMeError::HardwareSupport(ref m) => write!(f, "Hardware support: {}", m),
-            &TraceMeError::CFailure => write!(f, "Calling to C failed"),
-            &TraceMeError::ElfError(ref m) => write!(f, "ELF error: {}", m),
-            &TraceMeError::InvalidFileName(ref n) => write!(f, "Invalid file name: `{}'", n),
-            &TraceMeError::TracerAlreadyStarted => write!(f, "Tracer already started"),
-            &TraceMeError::TracerNotStarted => write!(f, "Tracer not started"),
-            &TraceMeError::TracingNotPermitted(ref m) => write!(f, "{}", m),
+        match *self {
+            TraceMeError::FFIIntoString(ref e) => write!(f, "{}", e),
+            TraceMeError::FFINul(ref e) => write!(f, "{}", e),
+            TraceMeError::IO(ref e) => write!(f, "{}", e),
+            TraceMeError::NumParseInt(ref e) => write!(f, "{}", e),
+            TraceMeError::HardwareSupport(ref m) => write!(f, "Hardware support: {}", m),
+            TraceMeError::CFailure => write!(f, "Calling to C failed"),
+            TraceMeError::ElfError(ref m) => write!(f, "ELF error: {}", m),
+            TraceMeError::InvalidFileName(ref n) => write!(f, "Invalid file name: `{}'", n),
+            TraceMeError::TracerAlreadyStarted => write!(f, "Tracer already started"),
+            TraceMeError::TracerNotStarted => write!(f, "Tracer not started"),
+            TraceMeError::TracingNotPermitted(ref m) => write!(f, "{}", m),
         }
     }
 }


### PR DESCRIPTION
A few bits detected by clippy.

I didn't accept all of clippy's advice. Here are the ones I think I'd rather *not* implement:

```
warning: you should consider deriving a `Default` implementation for `backends::dummy::DummyTracer`
  --> src/backends/dummy.rs:48:5
   |
48 | /     pub fn new() -> Self {
49 | |         Self {started: false}
50 | |     }
   | |_____^
   |
   = note: #[warn(new_without_default_derive)] on by default
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.177/index.html#new_without_default_derive
help: try this
   |
42 | #[derive(Default)]
   |

    Finished dev [unoptimized + debuginfo] target(s) in 0.26 secs
example: simple_example
   Compiling traceme v0.1.0 (file:///home/vext01/research/traceme)
warning: unneeded return statement
  --> examples/simple_example.rs:54:17
   |
54 |                 return Box::new(res.unwrap().trace_filename("simple_example.ptt"));
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove `return` as shown: `Box::new(res.unwrap().trace_filename("simple_example.ptt"))`
   |
   = note: #[warn(needless_return)] on by default
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.177/index.html#needless_return

warning: unneeded return statement
  --> examples/simple_example.rs:57:17
   |
57 |                 return Box::new(DummyTracer::new());
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove `return` as shown: `Box::new(DummyTracer::new())`
   |
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.177/index.html#needless_return

warning: unneeded return statement
  --> examples/simple_example.rs:64:9
   |
64 |         return Box::new(DummyTracer::new());
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove `return` as shown: `Box::new(DummyTracer::new())`
   |
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.177/index.html#needless_return
```

The return cases might make more sense if we didn't have the conditional compilation. What do you think?