### PR TITLE
Fix a bug where perf_pt tests don't receive any trace data.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # traceme
 
-A small Rust/C library to trace an arbitrary PID using Intel Processor Trace
+A small Rust/C library to trace an arbitrary thread using Intel Processor Trace
 (PT).
 
 **This is experimental code.**

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -36,11 +36,15 @@
 // SOFTWARE.
 
 use libc::{c_int, uintptr_t};
+#[cfg(target_os = "linux")]
+use libc::pid_t;
 use ::errors::TraceMeError;
 
 // FFI prototypes.
 extern "C" {
     fn traceme_exec_base(addr: *const uintptr_t) -> c_int;
+    #[cfg(target_os = "linux")]
+    fn traceme_linux_gettid() -> pid_t;
 }
 
 /// Get the relocated virtual start address of the executable code for the current program.
@@ -51,6 +55,12 @@ pub fn exec_base() -> Result<usize, TraceMeError> {
         1 => Ok(addr as usize),
         _ => unreachable!(),
     }
+}
+
+/// Get the thread ID of the current thread.
+#[cfg(target_os = "linux")]
+pub fn linux_gettid() -> pid_t {
+    unsafe { traceme_linux_gettid() }
 }
 
 #[cfg(all(test, target_os = "linux"))]

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -37,18 +37,21 @@
 
 #define _GNU_SOURCE
 
+#include <sys/syscall.h>
 #include <link.h>
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <libgen.h>
+#include <unistd.h>
 
 // Private prototypes.
 static int dl_iterate_phdr_cb(struct dl_phdr_info *, size_t, void *);
 
 // Exposed prototypes.
 int traceme_exec_base(uintptr_t *);
+pid_t traceme_linux_gettid(void);
 
 /*
  * Search program headers for the relocated start address of the current
@@ -110,3 +113,18 @@ dl_iterate_phdr_cb(struct dl_phdr_info *info, size_t size, void *data)
     return 0;
 }
 
+/*
+ * Get the thread ID of the current thread.
+ *
+ * This is a Linux specific notion. The pid_t type is overloaded to also refer
+ * to individual threads.
+ *
+ * At the time of writing, there is no glibc stub for this.
+ */
+#ifdef __linux__
+pid_t
+traceme_linux_gettid(void)
+{
+    return syscall(__NR_gettid);
+}
+#endif


### PR DESCRIPTION
For the perf_pt backend, we want to trace a thread ID (TID), not a
process (PID). A TID is a Linux specific notion, and unfortunately pid_t
is re-used for TIDs, which can lead to some confusion. I've updated doc
strings to try and make it clear to users.

The example code worked because the first thread of a program has the same TID as the PID. `cargo test` however, spawns a thread (with a new TID). We were tracing the main thread that's sat there twiddling it's thumbs waiting for the test thread to exit.

We can see the issue by looking at the debug output before and after this fix.

Before:
```
test backends::perf_pt::tests::test_basic_usage ...
...
rc/backends/perf_pt/perf_pt.c:220 [poll_loop]: wake
src/backends/perf_pt/perf_pt.c:221 [poll_loop]: aux_head=  0x0000000000
src/backends/perf_pt/perf_pt.c:222 [poll_loop]: aux_tail=  0x0000000000
src/backends/perf_pt/perf_pt.c:223 [poll_loop]: aux_offset=0x0000266240
src/backends/perf_pt/perf_pt.c:224 [poll_loop]: aux_size=  0x0004194304
```

Notice the head and tail are the same, so we read no data.

After:
```
test backends::perf_pt::tests::test_basic_usage ...
...
src/backends/perf_pt/perf_pt.c:220 [poll_loop]: wake
src/backends/perf_pt/perf_pt.c:221 [poll_loop]: aux_head=  0x0000000944
src/backends/perf_pt/perf_pt.c:222 [poll_loop]: aux_tail=  0x0000000000
src/backends/perf_pt/perf_pt.c:223 [poll_loop]: aux_offset=0x0000266240
src/backends/perf_pt/perf_pt.c:224 [poll_loop]: aux_size=  0x0004194304
```

Here we read 944 bytes out of the AUX buffer.