### PR TITLE
Trace to memory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ before_script:
 script:
     - cargo build --examples
     - cargo doc --no-deps
-    - RUST_TEST_THREADS=1 cargo test
+    - cargo test
     - ./target/debug/examples/simple_example

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["Edd Barrett <vext01@gmail.com>"]
 
 [dependencies]
 libc = "0.2.33"
+lazy_static = "1.0"
+time = "0.1"
 
 [build-dependencies]
 gcc = "0.3.54"

--- a/analyse.mk
+++ b/analyse.mk
@@ -1,8 +1,7 @@
 # Analyse for errors
 
 BIN=target/debug/examples/simple_example
-# XXX work out a way to kill sudo
-VALGRIND=sudo valgrind --error-exitcode=1
+VALGRIND=valgrind --error-exitcode=1
 
 all: valgrind
 

--- a/examples/simple_example.rs
+++ b/examples/simple_example.rs
@@ -51,7 +51,7 @@ fn tracer() -> Box<Tracer> {
         #[cfg(all(perf_pt, target_arch = "x86_64"))] {
             let res = PerfPTTracer::new();
             if res.is_ok() {
-                Box::new(res.unwrap().trace_filename("simple_example.ptt"))
+                Box::new(res.unwrap())
             } else {
                 // CPU doesn't have Intel PT support.
                 Box::new(DummyTracer::new())
@@ -77,10 +77,10 @@ fn main() {
         panic!(format!("Failed to start tracer: {}", e));
     });
 
-    for i in 1..10 {
+    for i in 1..10000 {
         res += i + pid;
     }
 
     tracer.stop_tracing().unwrap();
-    println!("result: {}", res);
+    println!("program result: {}", res);
 }

--- a/src/backends/dummy.rs
+++ b/src/backends/dummy.rs
@@ -37,6 +37,8 @@
 
 use Tracer;
 use errors::TraceMeError;
+use HWTrace;
+use std::ptr;
 
 /// A tracer which doesn't really do anything.
 pub struct DummyTracer {
@@ -59,12 +61,12 @@ impl Tracer for DummyTracer {
         Ok(())
     }
 
-    fn stop_tracing(&mut self) -> Result<(), TraceMeError> {
+    fn stop_tracing(&mut self) -> Result<HWTrace, TraceMeError> {
         if !self.started {
             return Err(TraceMeError::TracerNotStarted);
         }
         self.started = false;
-        Ok(())
+        Ok(HWTrace::from_buf(ptr::null(), 0)) // An empty trace.
     }
 }
 

--- a/src/backends/perf_pt/mod.rs
+++ b/src/backends/perf_pt/mod.rs
@@ -225,11 +225,11 @@ mod tests {
     use super::PerfPTTracer;
     use ::test_helpers;
 
-    fn run_test_helper<F>(f: F)  where F: Fn(PerfPTTracer) {
+    fn run_test_helper<F>(f: F) where F: Fn(PerfPTTracer) {
         let res = PerfPTTracer::new();
         // Only run the test if the CPU supports Intel PT.
-        if res.is_ok() {
-            f(res.unwrap());
+        if let Ok(tracer) = res {
+            f(tracer);
         }
     }
 

--- a/src/backends/perf_pt/mod.rs
+++ b/src/backends/perf_pt/mod.rs
@@ -69,7 +69,7 @@ pub struct PerfPTTracer {
     target_tid: pid_t,
     /// Data buffer size, in pages. Must be a power of 2.
     data_bufsize: size_t,
-    /// Aux buffer size, in pages. Must be a power of 2.
+    /// AUX buffer size, in pages. Must be a power of 2.
     aux_bufsize: size_t,
     /// Opaque C pointer representing the tracer context.
     tracer_ctx: Option<*const c_void>,
@@ -125,11 +125,11 @@ impl PerfPTTracer {
         self
     }
 
-    /// Set the PT aux buffer size.
+    /// Set the PT AUX buffer size.
     ///
     /// # Arguments
     ///
-    /// * `size` - The aux buffer size to use.
+    /// * `size` - The AUX buffer size to use.
     pub fn aux_bufsize(mut self, size: usize) -> Self {
         self.aux_bufsize = size;
         self

--- a/src/backends/perf_pt/mod.rs
+++ b/src/backends/perf_pt/mod.rs
@@ -35,13 +35,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-use libc::{pid_t, c_char, c_void, size_t, c_int, geteuid};
-use std::ffi::CString;
+use libc::{pid_t, c_void, size_t, c_int, geteuid};
 use errors::TraceMeError;
 use std::fs::File;
 use std::io::Read;
 use Tracer;
+use HWTrace;
 use util::linux_gettid;
+use std::ptr;
 
 // The sysfs path used to set perf permissions.
 const PERF_PERMS_PATH: &str = "/proc/sys/kernel/perf_event_paranoid";
@@ -49,7 +50,7 @@ const PERF_PERMS_PATH: &str = "/proc/sys/kernel/perf_event_paranoid";
 // FFI prototypes.
 extern "C" {
     fn perf_pt_start_tracer(conf: *const PerfPTConf) -> *const c_void;
-    fn perf_pt_stop_tracer(tr_ctx: *const c_void) -> c_int;
+    fn perf_pt_stop_tracer(tr_ctx: *const c_void, buf: *const *const u8, len: &u64) -> c_int;
 }
 
 // Struct used to communicate a tracing configuration to the C code. Must
@@ -57,7 +58,6 @@ extern "C" {
 #[repr(C)]
 struct PerfPTConf {
     target_tid: pid_t,
-    trace_filename: *const c_char,
     data_bufsize: size_t,
     aux_bufsize: size_t,
 }
@@ -65,8 +65,6 @@ struct PerfPTConf {
 /// A tracer that uses the Linux Perf interface to Intel Processor Trace.
 #[derive(Default)]
 pub struct PerfPTTracer {
-    /// Filename to store the trace to.
-    trace_filename: String,
     /// Thread ID to trace.
     target_tid: pid_t,
     /// Data buffer size, in pages. Must be a power of 2.
@@ -89,7 +87,7 @@ impl PerfPTTracer {
     ///
     /// let res = PerfPTTracer::new();
     /// if res.is_ok() {
-    ///     let tracer = res.unwrap().trace_filename("mytrace.ptt").data_bufsize(1024).target_tid(666);
+    ///     let tracer = res.unwrap().data_bufsize(1024).target_tid(666);
     /// } else {
     ///     // CPU doesn't support Intel Processor Trace.
     /// }
@@ -97,7 +95,6 @@ impl PerfPTTracer {
     pub fn new() -> Result<Self, TraceMeError> {
         if Self::pt_supported() {
             return Ok(Self {
-                trace_filename: String::from("traceme.ptt"),
                 target_tid: linux_gettid(),
                 tracer_ctx: None,
                 data_bufsize: 64,
@@ -105,16 +102,6 @@ impl PerfPTTracer {
             });
         }
         Err(TraceMeError::HardwareSupport("Intel PT not supported by CPU".into()))
-    }
-
-    /// Set where to write the trace.
-    ///
-    /// # Arguments
-    ///
-    /// * `filename` - The filename in which to store trace packets.
-    pub fn trace_filename(mut self, filename: &str) -> Self {
-        self.trace_filename = String::from(filename);
-        self
     }
 
     /// Select which thread to trace.
@@ -198,15 +185,10 @@ impl Tracer for PerfPTTracer {
         if self.tracer_ctx.is_some() {
             return Err(TraceMeError::TracerAlreadyStarted);
         }
-        if !self.trace_filename.ends_with(".ptt") {
-            return Err(TraceMeError::InvalidFileName(self.trace_filename.clone()));
-        }
 
         // Build the C configuration struct
-        let trace_filename_c = CString::new(self.trace_filename.clone())?;
         let tr_conf = PerfPTConf {
             target_tid: self.target_tid,
-            trace_filename: trace_filename_c.as_ptr(),
             data_bufsize: self.data_bufsize,
             aux_bufsize: self.aux_bufsize,
         };
@@ -223,15 +205,18 @@ impl Tracer for PerfPTTracer {
         Ok(())
     }
 
-    fn stop_tracing(&mut self) -> Result<(), TraceMeError> {
+    fn stop_tracing(&mut self) -> Result<HWTrace, TraceMeError> {
         let tr_ctx = self.tracer_ctx.ok_or(TraceMeError::TracerNotStarted)?;
+        let buf = ptr::null() as *const u8;
+        let len = 0;
         let rc = unsafe {
-            perf_pt_stop_tracer(tr_ctx)
+            perf_pt_stop_tracer(tr_ctx, &buf, &len)
         };
         if rc == -1 {
             return Err(TraceMeError::CFailure);
         }
-        Ok(())
+        let trace = HWTrace::from_buf(buf, len);
+        Ok(trace)
     }
 }
 

--- a/src/backends/perf_pt/perf_pt.c
+++ b/src/backends/perf_pt/perf_pt.c
@@ -93,7 +93,7 @@ struct tracer_ctx {
 struct tracer_conf {
     pid_t       target_tid;         // Thread ID to trace.
     size_t      data_bufsize;       // Data buf size (in pages).
-    size_t      aux_bufsize;        // Aux buf size (in pages).
+    size_t      aux_bufsize;        // AUX buf size (in pages).
 };
 
 /*
@@ -104,7 +104,7 @@ struct tracer_thread_args {
     int                 stop_fd_rd;         // Polled for "stop" event.
     sem_t               *tracer_init_sem;   // Tracer init sync.
     size_t              data_bufsize;       // Data buf size (in pages).
-    size_t              aux_bufsize;        // Aux buf size (in pages).
+    size_t              aux_bufsize;        // AUX buf size (in pages).
     void                **trace_buf;        // Pointer to the buffer to copy the trace into.
     __u64               trace_bufsize;      // Initial capacity of the trace buffer (in bytes).
     __u64               *trace_len;         // Pointer to the trace length (in bytes).
@@ -315,7 +315,7 @@ tracer_thread(void *arg)
     }
     sem_posted = 1;
 
-    // Start reading out of the aux buffer.
+    // Start reading out of the AUX buffer.
     if (!poll_loop(perf_fd, stop_fd_rd, header, aux, trace_buf,
                    trace_bufsize, trace_len)) {
         ret = false;
@@ -417,7 +417,7 @@ perf_pt_start_tracer(struct tracer_conf *tr_conf)
         &tr_ctx->trace_len,
     };
 
-    // Spawn a thread to deal with copying out of the PT aux buffer.
+    // Spawn a thread to deal with copying out of the PT AUX buffer.
     int rc = pthread_create(&tr_ctx->tracer_thread, NULL, tracer_thread, &thr_args);
     if (rc) {
         failing = true;

--- a/src/backends/perf_pt/perf_pt.c
+++ b/src/backends/perf_pt/perf_pt.c
@@ -58,10 +58,8 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
-#define TRACE_OUTPUT    "trace.data"
 #define SYSFS_PT_TYPE   "/sys/bus/event_source/devices/intel_pt/type"
 #define MAX_PT_TYPE_STR 8
-#define MAPS_MODE       S_IRUSR | S_IWUSR
 
 #ifndef INFTIM
 #define INFTIM -1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,12 +40,65 @@
 #![cfg_attr(feature="clippy", plugin(clippy))]
 
 extern crate libc;
+extern crate time;
 
 pub mod errors;
 pub mod backends;
 pub mod util;
 
 use errors::TraceMeError;
+use std::ops::Drop;
+use std::ptr;
+use libc::{free, c_void};
+
+#[cfg(debug_assertions)]
+use std::convert::AsRef;
+#[cfg(debug_assertions)]
+use std::path::Path;
+
+#[allow(dead_code)]
+pub struct HWTrace {
+    buf: *const u8,
+    len: u64,
+}
+
+impl HWTrace {
+    /// Makes a new trace from a raw pointer and a size.
+    ///
+    /// The `buf` argument is assumed to have been allocated on the heap using malloc(3). `len`
+    /// must be less than or equal to the allocated size.
+    ///
+    /// Once an instance is constructed, underlying allocation and it's freeing is the
+    /// responsibility of the instance.
+    fn from_buf(buf: *const u8, len: u64) -> Self {
+        Self {buf: buf, len: len}
+    }
+
+    /// Write the raw trace packets into the specified file.
+    ///
+    /// This can be useful for developers who want to use (e.g.) the pt utility to inspect the raw
+    /// packet stream.
+    #[cfg(debug_assertions)]
+    pub fn to_file<T>(&self, filename: T) where T: AsRef<Path> {
+        use std::slice;
+        use std::fs::File;
+        use std::io::prelude::*;
+
+        let mut f = File::create(filename).unwrap();
+        let slice = unsafe { slice::from_raw_parts(self.buf, self.len as usize) };
+        f.write(slice).unwrap();
+    }
+}
+
+/// Once a HWTrace is brought into existence, we say the instance owns the C-level allocation. When
+/// the HWTrace falls out of scope, free up the memory.
+impl Drop for HWTrace {
+    fn drop(&mut self) {
+        if self.buf != ptr::null() {
+            unsafe { free(self.buf as *mut c_void) };
+        }
+    }
+}
 
 /// The interface offered by all tracer types.
 ///
@@ -59,7 +112,43 @@ pub trait Tracer {
     /// Turns off the tracer.
     ///
     /// [start_tracing](trait.Tracer.html#method.start_tracing) must have been called prior.
-    fn stop_tracing(&mut self) -> Result<(), TraceMeError>;
+    fn stop_tracing(&mut self) -> Result<HWTrace, TraceMeError>;
+}
+
+/// XXX test to_file()
+#[cfg(all(test, debug_assertions))]
+mod tests {
+    use std::fs::File;
+    use std::slice;
+    use std::io::prelude::*;
+    use libc::malloc;
+    use super::HWTrace;
+
+    /// Test writing a trace to file.
+    #[test]
+    fn test_to_file() {
+        // Allocate and fill a buffer to make a "trace" from.
+        let size = 33;
+        let buf = unsafe { malloc(size) as *mut u8 };
+        let sl = unsafe { slice::from_raw_parts_mut(buf, size) };
+        for (i, byte) in sl.iter_mut().enumerate() {
+            *byte = i as u8;
+        }
+
+        // Make the trace and Write it to a file.
+        let filename = String::from("test_to_file.ptt");
+        let trace = HWTrace::from_buf(buf, size as u64);
+        trace.to_file(&filename);
+
+        // Check the resulting file makes sense.
+        let file = File::open(&filename).unwrap();
+        let mut total_bytes = 0;
+        for (i, byte) in file.bytes().enumerate() {
+            assert_eq!(i as u8, byte.unwrap());
+            total_bytes += 1;
+        }
+        assert_eq!(total_bytes, size);
+    }
 }
 
 /// Test helpers.
@@ -69,10 +158,21 @@ pub trait Tracer {
 #[cfg(test)]
 mod test_helpers {
     use super::{TraceMeError, Tracer};
+    use libc::getpid;
+
+    // A loop that does some work, that we can use to build a trace.
+    fn work_loop() {
+        let mut res = unsafe { getpid() };
+        for _ in 0..100 {
+            res += 33;
+        }
+        println!("{}", res); // Ensure the loop isn't optimised out.
+    }
 
     /// Check that starting and stopping a tracer works.
     pub fn test_basic_usage<T>(mut tracer: T) where T: Tracer {
         tracer.start_tracing().unwrap();
+        work_loop();
         tracer.stop_tracing().unwrap();
     }
 


### PR DESCRIPTION
This change allows us to trace to memory buffers, instead of files.

 * In doing so, we've allowed the tests to run in parallel. 
 * Once the trace pops out of C code, we say the underlying buffer is owned by `HWTrace`, hence we have a `drop` to free the buffer when it falls out of scope.
 * valgrind is happy
 * `HWTrace` will be a trait soon, as discussed.
 * A couple of semi-related bits in separate commits.

Please fire away with questions. I expect you will have loads.

